### PR TITLE
Implement wrapper for list-campaigns api call

### DIFF
--- a/lib/drip/client.rb
+++ b/lib/drip/client.rb
@@ -3,6 +3,7 @@ require "drip/client/accounts"
 require "drip/client/subscribers"
 require "drip/client/tags"
 require "drip/client/events"
+require "drip/client/campaigns"
 require "faraday"
 require "faraday_middleware"
 require "json"
@@ -13,6 +14,7 @@ module Drip
     include Subscribers
     include Tags
     include Events
+    include Campaigns
 
     attr_accessor :access_token, :api_key, :account_id
 

--- a/lib/drip/client/campaigns.rb
+++ b/lib/drip/client/campaigns.rb
@@ -1,0 +1,21 @@
+module Drip
+  class Client
+    module Campaigns
+      # Public: Fetch campaigns for this account
+      #
+      # options - A Hash of options
+      #           - status - Optional. Filter by one of the following statuses:
+      #                      draft, active, or paused. Defaults to all.
+      #           - page   - Optional. Use this parameter to paginate through
+      #                      your list of campaigns. Each response contains a
+      #                      a `meta` object that includes `total_count` and
+      #                      `total_pages` attributes.
+      #
+      # Returns a Drip::Response.
+      # See https://www.getdrip.com/docs.rest-api#campaigns
+      def campaigns(options = {})
+        get "#{account_id}/campaigns", options
+      end
+    end
+  end
+end

--- a/test/drip/client/campaigns_test.rb
+++ b/test/drip/client/campaigns_test.rb
@@ -1,0 +1,30 @@
+require File.dirname(__FILE__) + '/../../test_helper.rb'
+
+class Drip::Client::CampaignsTest < Drip::TestCase
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+
+    @connection = Faraday.new do |builder|
+      builder.adapter :test, @stubs
+    end
+
+    @client = Drip::Client.new { |c| c.account_id = "12345" }
+    @client.expects(:connection).at_least_once.returns(@connection)
+  end
+
+  context "#campaigns" do
+    setup do
+      @response_status = 200
+      @response_body = stub
+
+      @stubs.get "12345/campaigns" do
+        [@response_status, {}, @response_body]
+      end
+    end
+
+    should "send the right request" do
+      expected = Drip::Response.new(@response_status, @response_body)
+      assert_equal expected, @client.campaigns
+    end
+  end
+end


### PR DESCRIPTION
Allows a client to fetch campaigns:
```
client.campaigns # makes GET request to `:account_id/campaigns`
# => <Drip::Response>
```